### PR TITLE
Removed redundant code

### DIFF
--- a/Source/AssemblyInfo.cs
+++ b/Source/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// Internal types and methods exposed to the editor assembly for use in inspectors, editor windows, etc...
+[assembly: InternalsVisibleTo("UnityAtomsEditor")]

--- a/Source/AssemblyInfo.cs.meta
+++ b/Source/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27e12ac5abb620546af8017aab396d80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Source/Base/Variable/ScriptableObjectVariable.cs
+++ b/Source/Base/Variable/ScriptableObjectVariable.cs
@@ -4,7 +4,6 @@ using UnityEngine.Serialization;
 namespace UnityAtoms
 {
     public abstract class ScriptableObjectVariable<T, E1, E2> : ScriptableObjectVariableBase<T>,
-        IWithOldValue<T>,
         ISerializationCallbackReceiver
         where E1 : GameEvent<T>
         where E2 : GameEvent<T, T>

--- a/Source/Base/Variable/ScriptableObjectVariableBase.cs
+++ b/Source/Base/Variable/ScriptableObjectVariableBase.cs
@@ -5,13 +5,12 @@ using UnityEngine.Serialization;
 
 namespace UnityAtoms
 {
-    public abstract class ScriptableObjectVariableBase<T> : ScriptableObject, IWithValue<T>
+    public abstract class ScriptableObjectVariableBase<T> : ScriptableObject
     {
         public virtual T Value { get { return _value; } set { throw new NotImplementedException(); } }
 
         [Multiline]
         public string DeveloperDescription = "";
-
 
         [FormerlySerializedAs("value")]
         [SerializeField]

--- a/Source/Editor/CodeGenerator.cs
+++ b/Source/Editor/CodeGenerator.cs
@@ -1,13 +1,13 @@
 using System.IO;
 using System.Reflection;
+using UnityAtoms.Utils;
 using UnityEditor;
 using UnityEditor.Experimental.UIElements;
 using UnityEngine;
 using UnityEngine.Experimental.UIElements;
 using UnityEngine.Experimental.UIElements.StyleEnums;
-using UnityAtoms.Logger;
 
-namespace UnityAtoms
+namespace UnityAtoms.Editor
 {
     public class CodeGenerator : EditorWindow
     {
@@ -62,10 +62,10 @@ namespace UnityAtoms
         {
             if (string.IsNullOrEmpty(_typeName))
             {
-                AtomsLogger.Warning("You need to specify a type name. Aborting!");
+                Debug.LogWarning(RuntimeConstants.LOG_PREFIX + "You need to specify a type name. Aborting!");
                 return;
             }
-            AtomsLogger.Log("Generating " + _typeName);
+            Debug.Log(RuntimeConstants.LOG_PREFIX + " ::Generating " + _typeName);
 
             GenerateAction(_typeName);
             GenerateConstant(_typeName);

--- a/Source/Editor/GameEventEditor.cs
+++ b/Source/Editor/GameEventEditor.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UnityAtoms
 {
-    public abstract class GameEventEditor<T, E> : Editor
+    public abstract class GameEventEditor<T, E> : UnityEditor.Editor
         where E : GameEvent<T>
     {
         public override void OnInspectorGUI()

--- a/Source/Extensions/IListExtensions.cs
+++ b/Source/Extensions/IListExtensions.cs
@@ -4,126 +4,8 @@ using UnityEngine;
 
 namespace UnityAtoms.Extensions
 {
-    // Create an Action delegates that takes 5 parameters. Not included in the standard lib.
-    public delegate void Action<T1, T2, T3, T4, T5>(T1 p1, T2 p2, T3 p3, T4 p4, T5 p5);
-
     public static class IListExtensions
     {
-        public static void ForEach<T, P1>(this IList<T> list, Action<T, P1> action, P1 param1)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], param1);
-            }
-        }
-
-        public static void ForEach<T, P1, P2>(this IList<T> list, Action<T, P1, P2> action, P1 param1, P2 param2)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], param1, param2);
-            }
-        }
-
-        public static void ForEach<T, P1, P2, P3>(this IList<T> list, Action<T, P1, P2, P3> action, P1 param1, P2 param2, P3 param3)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], param1, param2, param3);
-            }
-        }
-
-        public static void ForEach<T, V, P1>(this IList<T> list, Func<T, V> selector, Action<V, P1> action, P1 param1)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(selector(list[i]), param1);
-            }
-        }
-
-        public static void ForEach<T, V, P1, P2>(this IList<T> list, Func<T, V> selector, Action<V, P1, P2> action, P1 param1, P2 param2)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(selector(list[i]), param1, param2);
-            }
-        }
-
-        public static void ForEach<T, V, P1, P2, P3>(this IList<T> list, Func<T, V> selector, Action<V, P1, P2, P3> action, P1 param1, P2 param2, P3 param3)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(selector(list[i]), param1, param2, param3);
-            }
-        }
-
-        public static void ForEach<T>(this IList<T> list, Action<T, int> action)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], i);
-            }
-        }
-
-        public static void ForEach<T, P1>(this IList<T> list, Action<T, int, P1> action, P1 param1)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], i, param1);
-            }
-        }
-
-        public static void ForEach<T, P1, P2>(this IList<T> list, Action<T, int, P1, P2> action, P1 param1, P2 param2)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], i, param1, param2);
-            }
-        }
-
-        public static void ForEach<T, P1, P2, P3>(this IList<T> list, Action<T, int, P1, P2, P3> action, P1 param1, P2 param2, P3 param3)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                action(list[i], i, param1, param2, param3);
-            }
-        }
-
-        public static R Reduce<R, T>(this IList<T> list, Func<R, R, R> reducer, Func<T, R> getValue, R initialValue, Func<T, bool> skip = null)
-        {
-            R accumulator = initialValue;
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                if (skip != null && skip(list[i]))
-                {
-                    continue;
-                }
-
-                accumulator = reducer(accumulator, getValue(list[i]));
-            }
-
-            return accumulator;
-        }
-
-        public static R Reduce<R, T, A>(this IList<T> list, Func<R, R, A, R> reducer, Func<T, R> getValue, R initialValue, A reducerArg1, Func<T, bool> skip = null)
-        {
-            R accumulator = initialValue;
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                if (skip != null && skip(list[i]))
-                {
-                    continue;
-                }
-
-                accumulator = reducer(accumulator, getValue(list[i]), reducerArg1);
-            }
-
-            return accumulator;
-        }
-
-        public static float ReturnMaxFloat(float acc, float cur) { return Mathf.Max(acc, cur); }
-        public static float ReturnMinFloat(float acc, float cur) { return Mathf.Min(acc, cur); }
-
         public static T First<T>(this IList<T> list, Func<T, bool> func)
         {
             for (int i = 0; list != null && i < list.Count; ++i)
@@ -132,69 +14,6 @@ namespace UnityAtoms.Extensions
             }
 
             return default(T);
-        }
-
-        public static T First<T, P1>(this IList<T> list, Func<T, P1, bool> func, P1 param1)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                if (func(list[i], param1)) return list[i];
-            }
-
-            return default(T);
-        }
-
-        public static bool Some<T>(this IList<T> list, Func<T, bool> func)
-        {
-            return !EqualityComparer<T>.Default.Equals(list.First(func), default(T));
-        }
-
-        public static bool Some<T, P1>(this IList<T> list, Func<T, P1, bool> func, P1 param1)
-        {
-            return !EqualityComparer<T>.Default.Equals(list.First(func, param1), default(T));
-        }
-
-        public static bool Every<T>(this List<T> list, Func<T, bool> func)
-        {
-            for (int i = 0; list != null && i < list.Count; ++i)
-            {
-                if (!func(list[i])) return false;
-            }
-
-            return true;
-        }
-
-        public static bool AddIfNotExists<T>(this IList<T> list, T item)
-        {
-            if (!list.Contains(item))
-            {
-                list.Add(item);
-                return true;
-            }
-
-            return false;
-        }
-
-        public static IList<T> ChainableAdd<T>(this IList<T> list, T item)
-        {
-            list.Add(item);
-            return list;
-        }
-
-        public static T GetOrInstantiate<T>(this IList<T> list, UnityEngine.Object prefab, Vector3 position, Quaternion quaternion, Func<T, bool> condition) where T : UnityEngine.Component
-        {
-            var component = list.First(condition);
-
-            if (component != null)
-            {
-                component.transform.position = position;
-                component.transform.rotation = quaternion;
-                return component;
-            }
-
-            var newComponent = GameObject.Instantiate(prefab, position, quaternion) as T;
-            list.Add(newComponent);
-            return newComponent;
         }
 
         public static GameObject GetOrInstantiate(this IList<GameObject> list, UnityEngine.Object prefab, Vector3 position, Quaternion quaternion, Func<GameObject, bool> condition)
@@ -211,13 +30,6 @@ namespace UnityAtoms.Extensions
             var newGameObject = GameObject.Instantiate(prefab, position, quaternion) as GameObject;
             list.Add(newGameObject);
             return newGameObject;
-        }
-
-        public static T InstantiateAndAdd<T>(this IList<T> list, UnityEngine.Object prefab, Vector3 position, Quaternion quaternion) where T : UnityEngine.Component
-        {
-            var component = GameObject.Instantiate(prefab, position, quaternion) as T;
-            list.Add(component);
-            return component;
         }
     }
 }

--- a/Source/Extensions/IListExtensions.cs.meta
+++ b/Source/Extensions/IListExtensions.cs.meta
@@ -1,11 +1,3 @@
-fileFormatVersion: 2
-guid: ce3494ed70b7ba944bec73e6d12efd03
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+﻿fileFormatVersion: 2
+guid: dcc7ab83ac924ebcbe10f80dae909195
+timeCreated: 1555250869

--- a/Source/MonoHooks/OnButtonClickHook.cs
+++ b/Source/MonoHooks/OnButtonClickHook.cs
@@ -1,8 +1,5 @@
 using UnityEngine;
 using UnityEngine.UI;
-#if UNITY_EDITOR
-using UnityAtoms.Logger;
-#endif
 
 namespace UnityAtoms
 {
@@ -12,28 +9,12 @@ namespace UnityAtoms
         private void Awake()
         {
             var button = GetComponent<Button>();
-            if (button == null)
-            {
-#if UNITY_EDITOR
-                AtomsLogger.Warning("OnButtonClickHook needs a Button component");
-#endif
-                return;
-            }
-
             button.onClick.AddListener(OnClick);
         }
 
         private void OnDestroy()
         {
             var button = GetComponent<Button>();
-            if (button == null)
-            {
-#if UNITY_EDITOR
-                AtomsLogger.Warning("OnButtonClickHook needs a Button component");
-#endif
-                return;
-            }
-
             button.onClick.RemoveListener(OnClick);
         }
 

--- a/Source/Types/Float/FloatVariable.cs
+++ b/Source/Types/Float/FloatVariable.cs
@@ -3,16 +3,7 @@ using UnityEngine;
 namespace UnityAtoms
 {
     [CreateAssetMenu(menuName = "Unity Atoms/Float/Variable", fileName = "FloatVariable", order = CreateAssetMenuUtils.Order.VARIABLE)]
-    public sealed class FloatVariable : EquatableScriptableObjectVariable<float, FloatEvent, FloatFloatEvent>, IWithApplyChange<float, FloatEvent, FloatFloatEvent>
+    public sealed class FloatVariable : EquatableScriptableObjectVariable<float, FloatEvent, FloatFloatEvent>
     {
-        public bool ApplyChange(float amount)
-        {
-            return SetValue(Value + amount);
-        }
-
-        public bool ApplyChange(EquatableScriptableObjectVariable<float, FloatEvent, FloatFloatEvent> amount)
-        {
-            return SetValue(Value + amount.Value);
-        }
     }
 }

--- a/Source/Types/GameObject/GetUnusedGameObject.cs
+++ b/Source/Types/GameObject/GetUnusedGameObject.cs
@@ -1,9 +1,8 @@
 using UnityEngine;
 using UnityAtoms.Extensions;
+using UnityAtoms.Utils;
+using UnityEngine.Assertions;
 using UnityEngine.Serialization;
-#if UNITY_EDITOR
-using UnityAtoms.Logger;
-#endif
 
 namespace UnityAtoms
 {
@@ -27,12 +26,9 @@ namespace UnityAtoms
 
         public override GameObject Call(Vector3 position, Quaternion quaternion)
         {
-            if (_isNotUsed == null)
-            {
-#if UNITY_EDITOR
-                AtomsLogger.Warning("IsUsed must be defined when using GetUnusedGameObject");
-#endif
-            }
+            Assert.IsNotNull(_list, RuntimeConstants.LOG_PREFIX + "List must be assigned in the inspector when using GetUnusedGameObject");
+            Assert.IsNotNull(_prefab, RuntimeConstants.LOG_PREFIX + "Prefab must be assigned in the inspector when using GetUnusedGameObject");
+            Assert.IsNotNull(_isNotUsed, RuntimeConstants.LOG_PREFIX + "IsUsed must be assigned in the inspector when using GetUnusedGameObject");
 
             return _list.List.GetOrInstantiate(_prefab, position, quaternion, _isNotUsed.Call);
         }

--- a/Source/Types/Int/IntVariable.cs
+++ b/Source/Types/Int/IntVariable.cs
@@ -3,16 +3,7 @@ using UnityEngine;
 namespace UnityAtoms
 {
     [CreateAssetMenu(menuName = "Unity Atoms/Int/Variable", fileName = "IntVariable", order = CreateAssetMenuUtils.Order.VARIABLE)]
-    public sealed class IntVariable : EquatableScriptableObjectVariable<int, IntEvent, IntIntEvent>, IWithApplyChange<int, IntEvent, IntIntEvent>
+    public sealed class IntVariable : EquatableScriptableObjectVariable<int, IntEvent, IntIntEvent>
     {
-        public bool ApplyChange(int amount)
-        {
-            return SetValue(Value + amount);
-        }
-
-        public bool ApplyChange(EquatableScriptableObjectVariable<int, IntEvent, IntIntEvent> amount)
-        {
-            return SetValue(Value + amount.Value);
-        }
     }
 }

--- a/Source/Utils/RuntimeConstants.cs
+++ b/Source/Utils/RuntimeConstants.cs
@@ -1,0 +1,14 @@
+namespace UnityAtoms.Utils
+{
+    /// <summary>
+    /// Internal constant and static readonly members for runtime usage.
+    /// </summary>
+    internal static class RuntimeConstants
+    {
+        /// <summary>
+        /// Prefix that should be pre-pended to all Debug.Logs made from UnityAtoms to help immediately inform
+        /// a user that those logs are made from this library.
+        /// </summary>
+        public const string LOG_PREFIX = "UnityAtoms :: ";
+    }
+}

--- a/Source/Utils/RuntimeConstants.cs.meta
+++ b/Source/Utils/RuntimeConstants.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1a6782aff26d4d53bcb182f39dbd8fac
+timeCreated: 1555251715


### PR DESCRIPTION
### Summary
This PR does a certain amount of housecleaning to removed redundant and unused types and methods. No functional changes should result in existing code in this library from this.

### Changes
* Removed redundant interfaces IWithValue<T> and IWithOldValue<T> as they and their methods are unused.
* Removed redundant extensions and util classes/methods as they are unused by anything in the library
* Created AssemblyInfo.cs file to contain [assembly] attributes to expose internal types and methods to the UnityAtomsEditor assembly. This makes it easier to keep non-user facing code as internal, but still expose it for Editor usage.
* Removed AtomsLogger as this class does not add any value to the library. Some situations where it was being used in to warn of missing components such as OnButtonClickHook were doing so to warn of a missing component when it was already guaranteed to be there via the [RequireComponent] attribute (situation could never occur where it was not present). In some cases it was being used situationally like an Assert for situations where an NRE or other exception would immediately follow. Replacing these with an Assert accomplishes the same goal of removing these logging checks for non-editor builds while at the same time forcefully throwing an error with a more user-friendly error if a non-descript error would immediately be thrown.
* Where logs were being made previously with AtomsLogger, if not replaced with an Assert or removed entirely they are now being made with a const LogPrefix in new internal static class RuntimeConstants