### PR TITLE
Unity Atoms 2019.2+ support

### DIFF
--- a/Source/UnityAtoms.asmdef
+++ b/Source/UnityAtoms.asmdef
@@ -1,3 +1,14 @@
 {
-	"name": "UnityAtoms"
+    "name": "UnityAtoms",
+    "references": [
+        "GUID:2bafac87e7f4b9b418d9448d219b01ab"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": []
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "com.mambojambostudios.unity-atoms",
     "displayName": "Unity Atoms",
     "version": "2.0.0",
-    "unity": "2018.3",
+    "unity": "2019.2",
     "description": "Tiny modular pieces utilizing the power of Scriptable Objects",
     "keywords": [
         "scriptable objects",


### PR DESCRIPTION
fixing #45 where in newer unity versions all ugui stuff is in an own package, which needed to be added in the assembly defintion.

**note**: I'd rather add this changes to its own branch (e.g. canary-2019.2 or whatever) because it could give problems with current stable unity versions (2018.3 or the 2018.4 LTS when it arrives) 

but when creating a pull request github does not allow to create a new target branch