### PR TITLE
Add discord link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The Unity Atoms docs are now published at **https://adamramberg.github.io/unity-
 
 Read [this](https://medium.com/@adamramberg/unity-atoms-tiny-modular-pieces-utilizing-the-power-of-scriptable-objects-e8add1b95201) article on Medium for a great introduction to Unity Atoms.
 
+## Looking for support?
+
+For questions and support please join our [Discord channel](https://discord.gg/W4yd7E7).
+
 ## Maintainers
 
 -   [AdamRamberg](https://github.com/AdamRamberg)

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -47,6 +47,13 @@ class Footer extends React.Component {
           <div>
             <h5>Community</h5>
             <a
+              href="https://discord.gg/W4yd7E7"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+            Discord
+            </a>
+            <a
               href="https://gitter.im/unity-atoms/community#"
               target="_blank"
               rel="noreferrer noopener"


### PR DESCRIPTION
Just created a Discord channel for Unity Atoms (see #59). This PR adds a link to the Discord channel in `README.md` and in the website's footer. 