### PR TITLE
Bux fix - name OnTriggerHook class properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 # [Unreleased]
 
+## 🐛 Bug fixes
+
+-   [#91](https://github.com/AdamRamberg/unity-atoms/issues/91) Name OnTriggerHook class properly. ([@AdamRamberg](https://github.com/AdamRamberg))
+
 ## 📝 Documentation
 
 -   [#73](https://github.com/AdamRamberg/unity-atoms/issues/73) Add discord link to docs. ([@AdamRamberg](https://github.com/AdamRamberg))

--- a/Packages/MonoHooks/Runtime/Hooks/OnTriggerHook.cs
+++ b/Packages/MonoHooks/Runtime/Hooks/OnTriggerHook.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms.MonoHooks
     /// </summary>
     [EditorIcon("atom-icon-delicate")]
     [AddComponentMenu("Unity Atoms/Hooks/On Trigger Hook")]
-    public sealed class OnTriggerStayHook : ColliderHook
+    public sealed class OnTriggerHook : ColliderHook
     {
         /// <summary>
         /// Set to true if Event should be triggered on `OnTriggerEnter`


### PR DESCRIPTION
OnTriggerHook was named "OnTriggerStayHook" and it was therefore not possible to use it. This naming bug is corrected in this PR.