### PR TITLE
Unity v2018.4 Support

### DIFF
--- a/Examples/Packages/manifest.json
+++ b/Examples/Packages/manifest.json
@@ -9,7 +9,7 @@
     "com.mambojambostudios.unity-atoms-ui": "file:../../Packages/UI",
     "com.mambojambostudios.unity-atoms-mono-hooks": "file:../../Packages/MonoHooks",
     "com.neuecc.unirx": "https://github.com/starikcetin/UniRx.git#7.1.0-upm",
-    "com.unity.package-manager-ui": "2.1.2",
+    "com.unity.package-manager-ui": "2.0.8",
     "com.unity.modules.animation": "1.0.0",
     "com.unity.modules.assetbundle": "1.0.0",
     "com.unity.modules.audio": "1.0.0",

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -1,4 +1,3 @@
-#if UNITY_2019_1_OR_NEWER
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -148,4 +147,3 @@ namespace UnityAtoms.Editor
         }
     }
 }
-#endif

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -1,3 +1,4 @@
+#if UNITY_2018_4_OR_NEWER
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -5,7 +6,7 @@ using UnityEngine;
 namespace UnityAtoms.Editor
 {
     /// <summary>
-    /// The base Unity Atoms property drawer. Makes it possible to create and add a new Atom via Unity's inspector. Only availble in `UNITY_2019_1_OR_NEWER`.
+    /// The base Unity Atoms property drawer. Makes it possible to create and add a new Atom via Unity's inspector. Only availble in `UNITY_2018_4_OR_NEWER`.
     /// </summary>
     /// <typeparam name="T">The type of Atom the property drawer should apply to.</typeparam>
     public abstract class AtomDrawer<T> : PropertyDrawer where T : ScriptableObject
@@ -147,3 +148,4 @@ namespace UnityAtoms.Editor
         }
     }
 }
+#endif

--- a/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
+++ b/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
@@ -1,3 +1,4 @@
+#if UNITY_2019_1_OR_NEWER
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -110,3 +111,4 @@ namespace UnityAtoms.Editor
 
     }
 }
+#endif

--- a/Packages/MonoHooks/Runtime/MamboJamboStudios.UnityAtomsMonoHooks.Runtime.asmdef
+++ b/Packages/MonoHooks/Runtime/MamboJamboStudios.UnityAtomsMonoHooks.Runtime.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "MamboJamboStudios.UnityAtomsMonoHooks.Runtime",
     "references": [
-        "GUID:14165214884ae4a619bfb290f28194a7"
+        "MamboJamboStudios.UnityAtomsCore.Runtime"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],
@@ -10,6 +10,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": []
+    "defineConstraints": []
 }


### PR DESCRIPTION
- Fixed MonoHooks asmdef reference to Core asmdef was broken.
- Fixed dependancy issue for Package Manager.
- Removed Generator function in version 2018.4.