### PR TITLE
IsUnityAtomsRepo should never be set

### DIFF
--- a/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
+++ b/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
@@ -64,9 +64,7 @@ namespace UnityAtoms.Editor
                 Debug.LogWarning("Cancelled generating Atoms.");
                 return;
             }
-#if UNITY_EDITOR
-            Runtime.IsUnityAtomsRepo = i == 0;
-#endif
+
             List<AtomType> ALL_ATOM_TYPES = new List<AtomType>()
             {
                 AtomTypes.ACTION,

--- a/Packages/Core/Runtime/Utils/Runtime.cs
+++ b/Packages/Core/Runtime/Utils/Runtime.cs
@@ -18,23 +18,13 @@ namespace UnityAtoms
             public const string LOG_PREFIX = "UnityAtoms :: ";
         }
 
-#if UNITY_EDITOR
-        private static bool? _isUnityAtomsRepo = false;
-#endif
-
         /// <summary>
         /// Determine if we are working the Unity Atoms source library / repo or not.
         /// </summary>
         /// <returns>`true` if we are working in the Unity Atoms source library / repo, otherwise `false`.</returns>
         public static bool IsUnityAtomsRepo
         {
-            #if !UNITY_EDITOR
             get => System.Environment.CurrentDirectory.Contains("unity-atoms/Examples");
-#else
-            get => (_isUnityAtomsRepo = (_isUnityAtomsRepo ?? System.Environment.CurrentDirectory.Contains("unity-atoms/Examples"))).Value;
-            set => _isUnityAtomsRepo = value;
-#endif
-
         }
     }
 }


### PR DESCRIPTION
This PR is removing leftovers from an old commit that is causing issues when generating atoms. Since the variable `_isUnityAtomsRepo` by default is set to false it sometimes falsely is returning false even though it should return true. By making IsUnityAtomsRepo none settable the issue is resolved.  