### PR TITLE
Fix variable equality issues

### DIFF
--- a/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomBaseVariable.cs
@@ -28,7 +28,7 @@ namespace UnityAtoms
     /// </summary>
     /// <typeparam name="T">The Variable value type.</typeparam>
     [EditorIcon("atom-icon-teal")]
-    public abstract class AtomBaseVariable<T> : AtomBaseVariable
+    public abstract class AtomBaseVariable<T> : AtomBaseVariable, IEquatable<AtomBaseVariable<T>>
     {
         /// <summary>
         /// The Variable value as an `object`.abstract Beware of boxing! 🥊
@@ -55,51 +55,15 @@ namespace UnityAtoms
         [SerializeField]
         protected T _value;
 
-        protected bool Equals(AtomBaseVariable<T> other)
-        {
-            return EqualityComparer<T>.Default.Equals(_value, other._value);
-        }
-
         /// <summary>
         /// Determines equality between Variables.
         /// </summary>
-        /// <param name="obj">The other Variable to compare as an `object`.</param>
+        /// <param name="other">The other Variable to compare.</param>
         /// <returns>`true` if they are equal, otherwise `false`.</returns>
-        public override bool Equals(object obj)
+        public bool Equals(AtomBaseVariable<T> other)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-            return Equals((AtomBaseVariable<T>)obj);
+            return other == this;
         }
-
-        /// <summary>
-        /// Get an unique hash code for this Variable based on the Variable's value.
-        /// </summary>
-        /// <returns>An unique hash.</returns>
-        public override int GetHashCode()
-        {
-            unchecked
-            {
-                return EqualityComparer<T>.Default.GetHashCode(_value);
-            }
-        }
-
-        /// <summary>
-        /// Equal operator.
-        /// </summary>
-        /// <param name="left">The first Variable to compare.</param>
-        /// <param name="right">The second Variable to compare.</param>
-        /// <returns>`true` if eqaul, otherwise `false`.</returns>
-        public static bool operator ==(AtomBaseVariable<T> left, AtomBaseVariable<T> right) { return Equals(left, right); }
-
-        /// <summary>
-        /// None equality operator.
-        /// </summary>
-        /// <param name="left">The first Variable to compare.</param>
-        /// <param name="right">The second Variable to compare.</param>
-        /// <returns>`true` if not eqaul, otherwise `false`.</returns>
-        public static bool operator !=(AtomBaseVariable<T> left, AtomBaseVariable<T> right) { return !Equals(left, right); }
 
         /// <summary>
         /// Not implemented.abstract Throws Exception

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -77,7 +77,7 @@ namespace UnityAtoms
         [SerializeField]
         private List<F> _preChangeTransformers = new List<F>();
 
-        protected abstract bool AreEqual(T first, T second);
+        protected abstract bool ValueEquals(T other);
 
         private void OnValidate()
         {
@@ -120,7 +120,7 @@ namespace UnityAtoms
         {
             var preProcessedNewValue = RunPreChangeTransformers(newValue);
 
-            if (!AreEqual(_value, preProcessedNewValue))
+            if (!ValueEquals(preProcessedNewValue))
             {
                 _oldValue = _value;
                 _value = preProcessedNewValue;

--- a/Packages/Core/Runtime/Variables/Collider2DVariable.cs
+++ b/Packages/Core/Runtime/Variables/Collider2DVariable.cs
@@ -10,9 +10,9 @@ namespace UnityAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Variables/Collider2D", fileName = "Collider2DVariable")]
     public sealed class Collider2DVariable : AtomVariable<Collider2D, Collider2DEvent, Collider2DCollider2DEvent, Collider2DCollider2DFunction>
     {
-        protected override bool AreEqual(Collider2D first, Collider2D second)
+        protected override bool ValueEquals(Collider2D other)
         {
-            return (first == null && second == null) || first != null && second != null && first == second;
+            return (_value == null && other == null) || _value != null && other != null && _value == other;
         }
     }
 }

--- a/Packages/Core/Runtime/Variables/ColliderVariable.cs
+++ b/Packages/Core/Runtime/Variables/ColliderVariable.cs
@@ -10,9 +10,9 @@ namespace UnityAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Variables/Collider", fileName = "ColliderVariable")]
     public sealed class ColliderVariable : AtomVariable<Collider, ColliderEvent, ColliderColliderEvent, ColliderColliderFunction>
     {
-        protected override bool AreEqual(Collider first, Collider second)
+        protected override bool ValueEquals(Collider other)
         {
-            return (first == null && second == null) || first != null && second != null && first == second;
+            return (_value == null && other == null) || _value != null && other != null && _value == other;
         }
     }
 }

--- a/Packages/Core/Runtime/Variables/EquatableAtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/EquatableAtomVariable.cs
@@ -8,9 +8,9 @@ namespace UnityAtoms
         where E2 : AtomEvent<T, T>
         where F : AtomFunction<T, T>
     {
-        protected override bool AreEqual(T t1, T t2)
+        protected override bool ValueEquals(T other)
         {
-            return (t1 == null && t2 == null) || (t1 != null && t1.Equals(t2));
+            return (_value == null && other == null) || (_value != null && _value.Equals(other));
         }
     }
 }

--- a/Packages/Core/Runtime/Variables/GameObjectVariable.cs
+++ b/Packages/Core/Runtime/Variables/GameObjectVariable.cs
@@ -10,9 +10,9 @@ namespace UnityAtoms
     [CreateAssetMenu(menuName = "Unity Atoms/Variables/GameObject", fileName = "GameObjectVariable")]
     public sealed class GameObjectVariable : AtomVariable<GameObject, GameObjectEvent, GameObjectGameObjectEvent, GameObjectGameObjectFunction>
     {
-        protected override bool AreEqual(GameObject first, GameObject second)
+        protected override bool ValueEquals(GameObject other)
         {
-            return (first == null && second == null) || first != null && second != null && first.GetInstanceID() == second.GetInstanceID();
+            return (_value == null && other == null) || _value != null && other != null && _value.GetInstanceID() == other.GetInstanceID();
         }
     }
 }

--- a/docs/introduction/generator.md
+++ b/docs/introduction/generator.md
@@ -64,7 +64,7 @@ public struct MyStruct : IEquatable<MyStruct>
 
 ```
 
-If your type does not implement [`IEquatable`](https://docs.microsoft.com/en-us/dotnet/api/system.iequatable-1?view=netframework-4.8) you will need to manually implement the `AreEqual` method in the generated `AtomVariable`.
+If your type does not implement [`IEquatable`](https://docs.microsoft.com/en-us/dotnet/api/system.iequatable-1?view=netframework-4.8) you will need to manually implement the `ValueEquals` method in the generated `AtomVariable`.
 
 ### Type namespace
 


### PR DESCRIPTION
This PR addresses #95. Besides that it changes the name on the `AreEquals` function to `ValueEquals`. 