### PR TITLE
Fix typo

### DIFF
--- a/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
@@ -7,7 +7,7 @@ namespace UnityAtoms
     /// <summary>
     /// A Variable Instancer is a MonoBehaviour that takes a variable as a base and creates an in memory copy of it OnEnable.
     /// This is handy when you want to use atoms for prefabs that are instantiated at runtime. Use together with AtomCollection to
-    /// react accordingly when a prefab with an assoicated atom is added or deleted to the scene.
+    /// react accordingly when a prefab with an associated atom is added or deleted to the scene.
     /// </summary>
     /// <typeparam name="V">Variable of type T.</typeparam>
     /// <typeparam name="T">The value type.</typeparam>

--- a/docs/api/unityatoms.md
+++ b/docs/api/unityatoms.md
@@ -788,7 +788,7 @@ Variable Instancer of type `Vector2`. Inherits from `AtomVariableInstancer<Vecto
 -   `E2` - Event x 2 of type T.
 -   `F` - Function of type T => T
 
-A Variable Instancer is a MonoBehaviour that takes a variable as a base and creates an in memory copy of it OnEnable. This is handy when you want to use atoms for prefabs that are instantiated at runtime. Use together with AtomCollection to react accordingly when a prefab with an assoicated atom is added or deleted to the scene.
+A Variable Instancer is a MonoBehaviour that takes a variable as a base and creates an in memory copy of it OnEnable. This is handy when you want to use atoms for prefabs that are instantiated at runtime. Use together with AtomCollection to react accordingly when a prefab with an associated atom is added or deleted to the scene.
 
 ### Variables
 


### PR DESCRIPTION
Just fix two typos.
The word `associated` has been misspelled as `assoicated` in:

- Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs line 10
- docs/api/unityatoms.md line 791