### PR TITLE
Using OdinInspector to draw event's Raise button (#142)

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -159,5 +159,13 @@ namespace UnityAtoms
                 }
             }
         }
+
+#if UNITY_EDITOR && ODIN_INSPECTOR
+        [Sirenix.OdinInspector.Button(Name = "Raise")]
+        private void OdinRaiseButton()
+        {
+            RaiseEditor(InspectorRaiseValue);
+        }
+#endif
     }
 }


### PR DESCRIPTION
When creating new AtomEvent types, you also have to create new Editor script to draw "Raise" button for that new AtomEvent. 
With this PR, If you have OdinInspector imported in your project, Odin takes care of drawing "Raise" button for you for the types that don't have Editor script. 
If you don't have Odin, nothing will happen.
If you have custom Editor scripts, Odin won't touch them. So existing editors still work.

This fixes #142.