### PR TITLE
Update AtomBaseReferenceDrawer.cs

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -71,7 +71,10 @@ namespace UnityAtoms.Editor
             var usageTypePropertyName = GetUsages(property)[newUsageValue].PropertyName;
             var usageTypeProperty = property.FindPropertyRelative(usageTypePropertyName);
 
-            if (usageTypePropertyName == "_value" && usageTypeProperty.hasVisibleChildren)
+
+            var valueFieldHeight = EditorGUI.GetPropertyHeight(property.FindPropertyRelative(usageTypePropertyName), label);
+
+            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight)
             {
                 EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
             }

--- a/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomBaseReferenceDrawer.cs
@@ -74,7 +74,7 @@ namespace UnityAtoms.Editor
 
             var valueFieldHeight = EditorGUI.GetPropertyHeight(property.FindPropertyRelative(usageTypePropertyName), label);
 
-            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight)
+            if (usageTypePropertyName == "_value" && valueFieldHeight > EditorGUIUtility.singleLineHeight+2)
             {
                 EditorGUI.PropertyField(originalPosition, usageTypeProperty, GUIContent.none, true);
             }


### PR DESCRIPTION
the changes introduced by #155 neglected that fields with visible children could use a custom drawer to render in a single line

![image](https://user-images.githubusercontent.com/3066582/86031298-f2565a80-ba35-11ea-92e3-537dfcc18a9e.png)

this patch addresses the problem

![image](https://user-images.githubusercontent.com/3066582/86031234-db176d00-ba35-11ea-9d86-5c80886eaeba.png)
