### PR TITLE
Fix Sub FSM Value issue

### DIFF
--- a/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachine.cs
+++ b/Packages/FSM/Runtime/FiniteStateMachine/FiniteStateMachine.cs
@@ -327,12 +327,9 @@ namespace UnityAtoms.FSM
             {
                 // Reset sub machines in to state
                 toState.SubMachine.Reset();
-                base.Value = toState.SubMachine.Value;
             }
-            else
-            {
-                base.Value = _currentTransition.ToState;
-            }
+
+            base.Value = _currentTransition.ToState;
             _currentFlatValue = _currentTransition.ToState;
             _currentTransition = null;
 


### PR DESCRIPTION
Fix for #176.

Turns out when updating FSMs, if a state has a Sub FSM, its Value is updated to be the Sub FSM's Value, and not the base FSM's Value, thereby rendering `submachine` null.