### PR TITLE
Add workaround for "Enter Play Mode" feature to enable initial values

### DIFF
--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace UnityAtoms
 {

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
+using UnityEditor;
 
 namespace UnityAtoms
 {
@@ -105,6 +106,13 @@ namespace UnityAtoms
         [SerializeField]
         private T _initialValue = default(T);
 
+#if UNITY_EDITOR
+        /// <summary>
+        /// List of all AtomVariable instances in editor.
+        /// </summary>
+        private static List<AtomVariable<T, P, E1, E2, F>> _instances = new List<AtomVariable<T, P, E1, E2, F>>();
+#endif
+
         /// <summary>
         /// When setting the value of a Variable the new value will be piped through all the pre change transformers, which allows you to create custom logic and restriction on for example what values can be set for this Variable.
         /// </summary>
@@ -138,10 +146,36 @@ namespace UnityAtoms
 
         private void OnEnable()
         {
+            SetInitialValues();
+            TriggerInitialEvents();
+
+#if UNITY_EDITOR
+            if (EditorSettings.enterPlayModeOptionsEnabled)
+            {
+                _instances.Remove(this);
+                _instances.Add(this);
+
+                EditorApplication.playModeStateChanged -= HandlePlayModeStateChange;
+                EditorApplication.playModeStateChanged += HandlePlayModeStateChange;
+            }
+#endif
+        }
+
+        /// <summary>
+        /// Set initial values
+        /// </summary>
+        private void SetInitialValues()
+        {
             _oldValue = InitialValue;
             _value = InitialValue;
+        }
 
-            if (_triggerChangedOnOnEnable)
+        /// <summary>
+        /// Trigger initial events if related options enabled
+        /// </summary>
+        private void TriggerInitialEvents()
+        {
+            if (Changed != null && _triggerChangedOnOnEnable)
             {
                 Changed.Raise(Value);
             }
@@ -153,6 +187,27 @@ namespace UnityAtoms
                 ChangedWithHistory.Raise(pair);
             }
         }
+
+
+#if UNITY_EDITOR
+        private static void HandlePlayModeStateChange(PlayModeStateChange state)
+        {
+            if (state == PlayModeStateChange.ExitingEditMode)
+            {
+                _instances.ForEach(instance =>
+                {
+                    instance.SetInitialValues();
+                });
+            }
+            else if (state == PlayModeStateChange.EnteredPlayMode)
+            {
+                _instances.ForEach(instance =>
+                {
+                    instance.TriggerInitialEvents();
+                });
+            }
+        }
+#endif
 
         /// <summary>
         /// Reset the Variable to its `_initialValue`.

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -110,9 +110,9 @@ namespace UnityAtoms
 
 #if UNITY_EDITOR
         /// <summary>
-        /// List of all AtomVariable instances in editor.
+        /// Set of all AtomVariable instances in editor.
         /// </summary>
-        private static List<AtomVariable<T, P, E1, E2, F>> _instances = new List<AtomVariable<T, P, E1, E2, F>>();
+        private static HashSet<AtomVariable<T, P, E1, E2, F>> _instances = new HashSet<AtomVariable<T, P, E1, E2, F>>();
 #endif
 
         /// <summary>
@@ -154,7 +154,6 @@ namespace UnityAtoms
 #if UNITY_EDITOR
             if (EditorSettings.enterPlayModeOptionsEnabled)
             {
-                _instances.Remove(this);
                 _instances.Add(this);
 
                 EditorApplication.playModeStateChanged -= HandlePlayModeStateChange;
@@ -196,17 +195,17 @@ namespace UnityAtoms
         {
             if (state == PlayModeStateChange.ExitingEditMode)
             {
-                _instances.ForEach(instance =>
+                foreach (var instance in _instances)
                 {
                     instance.SetInitialValues();
-                });
+                }
             }
             else if (state == PlayModeStateChange.EnteredPlayMode)
             {
-                _instances.ForEach(instance =>
+                foreach (var instance in _instances)
                 {
                     instance.TriggerInitialEvents();
-                });
+                };
             }
         }
 #endif


### PR DESCRIPTION
This may not be the optimal solution but It seems working and we can think this as a workaround until we find a better approach.

**Important Note:** If you enable the "Enter Pay Mode" feature in Unity, you have to restart the editor to make this workaround work.