### PR TITLE
Creating new atom in current directory improvement

### DIFF
--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -102,9 +102,11 @@ namespace UnityAtoms.Editor
                         {
                             try
                             {
+                                string path = AssetDatabase.GetAssetPath(property.serializedObject.targetObject);
+                                path = path == "" ? "Assets/" : path;
                                 // Create asset
                                 T so = ScriptableObject.CreateInstance<T>();
-                                AssetDatabase.CreateAsset(so, "Assets/" + drawerData.NameOfNewAtom + ".asset");
+                                AssetDatabase.CreateAsset(so, path + drawerData.NameOfNewAtom + ".asset");
                                 AssetDatabase.SaveAssets();
                                 // Assign the newly created SO
                                 property.objectReferenceValue = so;

--- a/Packages/Core/Editor/Drawers/AtomDrawer.cs
+++ b/Packages/Core/Editor/Drawers/AtomDrawer.cs
@@ -1,5 +1,6 @@
 #if UNITY_2018_3_OR_NEWER
 using System.Collections.Generic;
+using System.IO;
 using UnityEditor;
 using UnityEngine;
 
@@ -103,7 +104,7 @@ namespace UnityAtoms.Editor
                             try
                             {
                                 string path = AssetDatabase.GetAssetPath(property.serializedObject.targetObject);
-                                path = path == "" ? "Assets/" : path;
+                                path = path == "" ? "Assets/" : Path.GetDirectoryName(path) + "/";
                                 // Create asset
                                 T so = ScriptableObject.CreateInstance<T>();
                                 AssetDatabase.CreateAsset(so, path + drawerData.NameOfNewAtom + ".asset");


### PR DESCRIPTION
It's annoying when new Atom, Event is created in root Asset directory. It's a small improvement that adds support for creating a new .asset file in the current ScriptableObject directory if SO is selected. If GameObject on the scene is selected it creates in root Asset folder, because it's impossible to detect directory.
#185 