### PR TITLE
 asset based atoms generation

### DIFF
--- a/Packages/Core/Editor/Editors/AtomFolderEditor.cs
+++ b/Packages/Core/Editor/Editors/AtomFolderEditor.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+namespace UnityAtoms.Editor
+{
+    [CustomEditor(typeof(DefaultAsset))]
+    public class AtomFolderEditor : UnityEditor.Editor
+    {
+        protected override void OnHeaderGUI()
+        {
+            base.OnHeaderGUI();
+
+            if(! Directory.Exists(AssetDatabase.GetAssetPath(target))) return;
+            if (!target.name.ToLowerInvariant().Contains("atom")) return;
+
+
+            GUILayout.Label("UNITY ATOMS", (GUIStyle)"AC BoldHeader", GUILayout.ExpandWidth(true));
+
+            if (GUILayout.Button("Add Generator", (GUIStyle)"LargeButton"))
+            {
+                var asset = CreateInstance<AtomGenerator>();
+                var newPath = Path.Combine(
+                    AssetDatabase.GetAssetPath(target),
+                    "New Atom Type.asset"
+                );
+                Debug.Log(newPath);
+                AssetDatabase.CreateAsset(asset, newPath);
+                AssetDatabase.ImportAsset(newPath);
+            }
+        }
+
+    }
+}

--- a/Packages/Core/Editor/Editors/AtomFolderEditor.cs
+++ b/Packages/Core/Editor/Editors/AtomFolderEditor.cs
@@ -11,13 +11,12 @@ namespace UnityAtoms.Editor
         {
             base.OnHeaderGUI();
 
-            if(! Directory.Exists(AssetDatabase.GetAssetPath(target))) return;
+            if (!Directory.Exists(AssetDatabase.GetAssetPath(target))) return;
             if (!target.name.ToLowerInvariant().Contains("atom")) return;
 
+            GUILayout.Label("UNITY ATOMS", (GUIStyle) "AC BoldHeader", GUILayout.ExpandWidth(true));
 
-            GUILayout.Label("UNITY ATOMS", (GUIStyle)"AC BoldHeader", GUILayout.ExpandWidth(true));
-
-            if (GUILayout.Button("Add Generator", (GUIStyle)"LargeButton"))
+            if (GUILayout.Button("Add Generator", (GUIStyle) "LargeButton"))
             {
                 var asset = CreateInstance<AtomGenerator>();
                 var newPath = Path.Combine(
@@ -29,6 +28,5 @@ namespace UnityAtoms.Editor
                 AssetDatabase.ImportAsset(newPath);
             }
         }
-
     }
 }

--- a/Packages/Core/Editor/Editors/AtomFolderEditor.cs.meta
+++ b/Packages/Core/Editor/Editors/AtomFolderEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f56d91dda58c8e4ea7e0d01fccdc636
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs
+++ b/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using UnityEditor;
+using UnityEditor.IMGUI.Controls;
+using UnityEngine;
+using UnityAtoms;
+
+namespace UnityAtoms.Editor
+{
+    [CustomEditor(typeof(AtomGenerator))]
+    public class AtomGeneratorEditor : UnityEditor.Editor
+    {
+        IEnumerable<IGrouping<string, Type>> types;
+        private SearchTypeDropdown typeSelectorPopup;
+        private void OnEnable()
+        {
+            types = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(assembly => assembly.GetExportedTypes())
+                .Where(x => x != null)
+                .Where(x => (x.Attributes & TypeAttributes.Serializable) != 0)
+                // .Where(t => !(t.Namespace?.Contains("System") ?? false))
+                .Where(t => !(t.Namespace?.Contains("Microsoft") ?? false))
+                .Where(t => !(t.Namespace?.Contains("UnityEditor") ?? false))
+                .GroupBy(t => t.Namespace.Split('.')[0]);
+        }
+
+        public override void OnInspectorGUI()
+        {
+            //UnityEditor.Editor.DrawPropertiesExcluding(serializedObject);
+
+            Rect buttonRect = new Rect();
+            var rect = GUILayoutUtility.GetRect(new GUIContent("Show"), EditorStyles.toolbarButton);
+
+
+            if (GUILayout.Button("Select Type"))
+            {
+                var dropdown = new SearchTypeDropdown(new AdvancedDropdownState(), types, (s) =>
+                {
+                    serializedObject.FindProperty("Namespace").stringValue = s.Split(':')[0];
+                    serializedObject.FindProperty("BaseType").stringValue  = s.Split(':')[1];
+                });
+                dropdown.Show(rect);
+            }
+
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("Namespace"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("BaseType"));
+
+            var options = serializedObject.FindProperty("GenerationOptions").intValue;
+
+            var scripts = (target as AtomGenerator)?.Scripts;
+            for (var index = 0; index < AtomTypes.ALL_ATOM_TYPES.Count; index++)
+            {
+                var option = AtomTypes.ALL_ATOM_TYPES[index];
+
+                EditorGUILayout.BeginHorizontal();
+
+                bool b = (options & (1 <<index)) == (1 <<index);
+                EditorGUI.BeginChangeCheck();
+                b = EditorGUILayout.Toggle(AtomTypes.ALL_ATOM_TYPES[index].DisplayName, b);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    if (b)
+                    {
+                        options |= (1 << index);
+                        // add all dependencies:
+                        if(AtomTypes.DEPENDENCY_GRAPH.TryGetValue(option, out var list))
+                            list.ForEach(dep => options |= (1 << AtomTypes.ALL_ATOM_TYPES.IndexOf(dep)));
+                    }
+                    else
+                    {
+                        options &= ~(1 << index);
+                        // remove all depending:
+                        foreach (var keyValuePair in AtomTypes.DEPENDENCY_GRAPH.Where(kv => kv.Value.Contains(option)))
+                        {
+                            options &= ~(1 << AtomTypes.ALL_ATOM_TYPES.IndexOf(keyValuePair.Key));
+                        }
+                    }
+                }
+
+                if (scripts != null && index < scripts.Count && scripts[index] != null)
+                {
+                    EditorGUILayout.ObjectField(scripts[index], typeof(MonoScript), false, GUILayout.Width(200));
+                }
+                else
+                {
+                    EditorGUILayout.LabelField(GUIContent.none, GUILayout.Width(200));
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            serializedObject.FindProperty("GenerationOptions").intValue = options;
+
+            serializedObject.ApplyModifiedProperties();
+            if (GUILayout.Button("(Re)Generate"))
+            {
+                (target as AtomGenerator)?.Generate();
+                AssetDatabase.SaveAssets();
+            }
+        }
+
+        private class SearchTypeDropdown : AdvancedDropdown
+        {
+            private readonly IEnumerable<IGrouping<string, Type>> _list;
+            private readonly Action<string> _func;
+
+            public SearchTypeDropdown(AdvancedDropdownState state, IEnumerable<IGrouping<string, Type>> list, Action<string> func) : base(state)
+            {
+                _list = list;
+                _func = func;
+            }
+
+            protected override void ItemSelected(AdvancedDropdownItem item)
+            {
+                base.ItemSelected(item);
+                _func?.Invoke(item.name);
+            }
+
+            protected override AdvancedDropdownItem BuildRoot()
+            {
+                var root = new AdvancedDropdownItem("Serializable Types");
+
+
+                foreach (var group in _list)
+                {
+                    var groupItem = new AdvancedDropdownItem(group.Key);
+                    foreach (var type in group)
+                    {
+                        groupItem.AddChild(new AdvancedDropdownItem(group.Key + ":"+ type.Name));
+                    }
+                    root.AddChild(groupItem);
+                }
+                return root;
+            }
+        }
+
+
+    }
+
+
+}

--- a/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs
+++ b/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs
@@ -21,7 +21,7 @@ namespace UnityAtoms.Editor
             types = AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(assembly => assembly.GetExportedTypes())
                 .Where(x => x != null)
-                .Where(x => (x.Attributes & TypeAttributes.Serializable) != 0)
+                .Where(x => x.IsValueType || (x.Attributes & TypeAttributes.Serializable) != 0)
                 // .Where(t => !(t.Namespace?.Contains("System") ?? false))
                 .Where(t => !(t.Namespace?.Contains("Microsoft") ?? false))
                 .Where(t => !(t.Namespace?.Contains("UnityEditor") ?? false))
@@ -42,12 +42,16 @@ namespace UnityAtoms.Editor
                 {
                     serializedObject.FindProperty("Namespace").stringValue = s.Split(':')[0];
                     serializedObject.FindProperty("BaseType").stringValue  = s.Split(':')[1];
+                    var type = types.First(grouping => grouping.Key == serializedObject.FindProperty("Namespace").stringValue)
+                        .First(t => t.Name == serializedObject.FindProperty("BaseType").stringValue);
+                    serializedObject.FindProperty("FullQualifiedName").stringValue = type.AssemblyQualifiedName;
                 });
                 dropdown.Show(rect);
             }
 
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("Namespace"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("BaseType"));
+            // EditorGUILayout.PropertyField(serializedObject.FindProperty("Namespace"));
+            // EditorGUILayout.PropertyField(serializedObject.FindProperty("BaseType"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("FullQualifiedName"));
 
             var options = serializedObject.FindProperty("GenerationOptions").intValue;
 

--- a/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs.meta
+++ b/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 02004ea5719f46c3bbf2470218a5aed2
+timeCreated: 1587244587

--- a/Packages/Core/Editor/Generator/AtomGenerator.cs
+++ b/Packages/Core/Editor/Generator/AtomGenerator.cs
@@ -2,9 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
 using UnityEditor;
-using UnityEditor.VersionControl;
 using UnityEngine;
 
 namespace UnityAtoms.Editor
@@ -24,14 +22,17 @@ namespace UnityAtoms.Editor
         public void Generate()
         {
             var type = Type.GetType($"{FullQualifiedName}");
-            if(type == null) throw new TypeLoadException($"Type could not be found ({FullQualifiedName})");
+            if (type == null) throw new TypeLoadException($"Type could not be found ({FullQualifiedName})");
             var isValueTypeEquatable = type.GetInterfaces().Contains(typeof(IEquatable<>));
 
             var templateVariables = Generator.CreateTemplateVariablesMap(BaseType, Namespace, "BaseAtoms");
             var capitalizedValueType = BaseType.Capitalize();
             var templates = Generator.GetTemplatePaths();
-            var templateConditions = Generator.CreateTemplateConditions(isValueTypeEquatable, Namespace, "BaseAtoms", BaseType);
-            var baseWritePath = Path.Combine((Path.GetDirectoryName(AssetDatabase.GetAssetPath(this.GetInstanceID()))) ?? "Assets/", "Generated");
+            var templateConditions =
+                Generator.CreateTemplateConditions(isValueTypeEquatable, Namespace, "BaseAtoms", BaseType);
+            var baseWritePath =
+                Path.Combine((Path.GetDirectoryName(AssetDatabase.GetAssetPath(this.GetInstanceID()))) ?? "Assets/",
+                    "Generated");
 
             Directory.CreateDirectory(baseWritePath);
 
@@ -44,18 +45,21 @@ namespace UnityAtoms.Editor
                 {
                     var atomType = AtomTypes.ALL_ATOM_TYPES[idx];
 
-                    templateVariables["VALUE_TYPE_NAME"] = atomType.IsValuePair ? $"{capitalizedValueType}Pair" : capitalizedValueType;
+                    templateVariables["VALUE_TYPE_NAME"] =
+                        atomType.IsValuePair ? $"{capitalizedValueType}Pair" : capitalizedValueType;
                     var valueType = atomType.IsValuePair ? $"{capitalizedValueType}Pair" : BaseType;
                     templateVariables["VALUE_TYPE"] = valueType;
 
-                    var resolvedRelativeFilePath = Templating.ResolveVariables(templateVariables: templateVariables, toResolve: atomType.RelativeFileNameAndPath);
+                    var resolvedRelativeFilePath = Templating.ResolveVariables(templateVariables: templateVariables,
+                        toResolve: atomType.RelativeFileNameAndPath);
                     var targetPath = Path.Combine(baseWritePath, resolvedRelativeFilePath);
 
                     var newCreated = !File.Exists(targetPath);
 
-                    Generator.Generate(new AtomReceipe(atomType, valueType), baseWritePath, templates, templateConditions, templateVariables);
+                    Generator.Generate(new AtomReceipe(atomType, valueType), baseWritePath, templates,
+                        templateConditions, templateVariables);
 
-                    if(newCreated) AssetDatabase.ImportAsset(targetPath);
+                    if (newCreated) AssetDatabase.ImportAsset(targetPath);
                     var ms = AssetDatabase.LoadAssetAtPath<MonoScript>(targetPath);
                     Scripts.Add(ms);
                 }
@@ -63,14 +67,10 @@ namespace UnityAtoms.Editor
                 {
                     Scripts.Add(null);
                 }
+
                 idx++;
                 t >>= 1;
             }
-
         }
     }
-
-
-
-
 }

--- a/Packages/Core/Editor/Generator/AtomGenerator.cs
+++ b/Packages/Core/Editor/Generator/AtomGenerator.cs
@@ -12,6 +12,7 @@ namespace UnityAtoms.Editor
     [CreateAssetMenu(fileName = "AtomGenerator", menuName = "Unity Atoms/Generation/AtomGenerator", order = 0)]
     public class AtomGenerator : ScriptableObject
     {
+        public string FullQualifiedName;
         public string Namespace;
         public string BaseType;
 
@@ -22,8 +23,8 @@ namespace UnityAtoms.Editor
 
         public void Generate()
         {
-            var type = Type.GetType($"{Namespace}.{BaseType}");
-            if(type == null) throw new TypeLoadException($"Type could not be found ({Namespace}.{BaseType})");
+            var type = Type.GetType($"{FullQualifiedName}");
+            if(type == null) throw new TypeLoadException($"Type could not be found ({FullQualifiedName})");
             var isValueTypeEquatable = type.GetInterfaces().Contains(typeof(IEquatable<>));
 
             var templateVariables = Generator.CreateTemplateVariablesMap(BaseType, Namespace, "BaseAtoms");

--- a/Packages/Core/Editor/Generator/AtomGenerator.cs
+++ b/Packages/Core/Editor/Generator/AtomGenerator.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using UnityEditor;
+using UnityEditor.VersionControl;
+using UnityEngine;
+
+namespace UnityAtoms.Editor
+{
+    [CreateAssetMenu(fileName = "AtomGenerator", menuName = "Unity Atoms/Generation/AtomGenerator", order = 0)]
+    public class AtomGenerator : ScriptableObject
+    {
+        public string Namespace;
+        public string BaseType;
+
+        public int GenerationOptions;
+
+        // Referencing Generated Files here:
+        public List<MonoScript> Scripts = new List<MonoScript>(AtomTypes.ALL_ATOM_TYPES.Count);
+
+        public void Generate()
+        {
+            var type = Type.GetType($"{Namespace}.{BaseType}");
+            if(type == null) throw new TypeLoadException($"Type could not be found ({Namespace}.{BaseType})");
+            var isValueTypeEquatable = type.GetInterfaces().Contains(typeof(IEquatable<>));
+
+            var templateVariables = Generator.CreateTemplateVariablesMap(BaseType, Namespace, "BaseAtoms");
+            var capitalizedValueType = BaseType.Capitalize();
+            var templates = Generator.GetTemplatePaths();
+            var templateConditions = Generator.CreateTemplateConditions(isValueTypeEquatable, Namespace, "BaseAtoms", BaseType);
+            var baseWritePath = Path.Combine((Path.GetDirectoryName(AssetDatabase.GetAssetPath(this.GetInstanceID()))) ?? "Assets/", "Generated");
+
+            Directory.CreateDirectory(baseWritePath);
+
+            Scripts.Clear();
+            var t = GenerationOptions;
+            var idx = 0;
+            while (t > 0)
+            {
+                if (t % 2 == 1)
+                {
+                    var atomType = AtomTypes.ALL_ATOM_TYPES[idx];
+
+                    templateVariables["VALUE_TYPE_NAME"] = atomType.IsValuePair ? $"{capitalizedValueType}Pair" : capitalizedValueType;
+                    var valueType = atomType.IsValuePair ? $"{capitalizedValueType}Pair" : BaseType;
+                    templateVariables["VALUE_TYPE"] = valueType;
+
+                    var resolvedRelativeFilePath = Templating.ResolveVariables(templateVariables: templateVariables, toResolve: atomType.RelativeFileNameAndPath);
+                    var targetPath = Path.Combine(baseWritePath, resolvedRelativeFilePath);
+
+                    var newCreated = !File.Exists(targetPath);
+
+                    Generator.Generate(new AtomReceipe(atomType, valueType), baseWritePath, templates, templateConditions, templateVariables);
+
+                    if(newCreated) AssetDatabase.ImportAsset(targetPath);
+                    var ms = AssetDatabase.LoadAssetAtPath<MonoScript>(targetPath);
+                    Scripts.Add(ms);
+                }
+                else
+                {
+                    Scripts.Add(null);
+                }
+                idx++;
+                t >>= 1;
+            }
+
+        }
+    }
+
+
+
+
+}

--- a/Packages/Core/Editor/Generator/AtomGenerator.cs.meta
+++ b/Packages/Core/Editor/Generator/AtomGenerator.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 734fbfb568154d32a89d792102f0c779
+timeCreated: 1595876056

--- a/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
+++ b/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
@@ -3,6 +3,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using UnityEditor;
 using UnityEngine;
 
@@ -31,6 +32,27 @@ namespace UnityAtoms.Editor
                 this.ValueTypeNamespace = typeNamespace;
                 this.SubUnityAtomsNamespace = subUnityAtomsNamespace;
             }
+        }
+
+        [MenuItem("Tools/Unity Atoms/Regenerate Atoms from Assets")]
+        static void RegenereateAssets()
+        {
+            if (! EditorUtility.DisplayDialog("Regenerate", "This will regenerate all Atoms from Generation-Assets", "ok", "cancel"))
+            {
+                return;
+            }
+            var guids = AssetDatabase.FindAssets($"t:{nameof(AtomGenerator)}");
+
+            //StringBuilder sb = new StringBuilder();
+            foreach (var guid in guids)
+            {
+                // sb.Append("regenerate ");
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                // sb.AppendLine(path);
+                AssetDatabase.LoadAssetAtPath<AtomGenerator>(path).Generate();
+            }
+            //Debug.Log(sb.ToString());
+
         }
 
         /// <summary>

--- a/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
+++ b/Packages/Core/Editor/Generator/RegenerateAllAtoms.cs
@@ -1,9 +1,7 @@
 #if UNITY_2018_3_OR_NEWER
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using UnityEditor;
 using UnityEngine;
 
@@ -37,22 +35,20 @@ namespace UnityAtoms.Editor
         [MenuItem("Tools/Unity Atoms/Regenerate Atoms from Assets")]
         static void RegenereateAssets()
         {
-            if (! EditorUtility.DisplayDialog("Regenerate", "This will regenerate all Atoms from Generation-Assets", "ok", "cancel"))
+            if (!EditorUtility.DisplayDialog("Regenerate", "This will regenerate all Atoms from Generation-Assets",
+                "ok", "cancel"))
             {
                 return;
             }
-            var guids = AssetDatabase.FindAssets($"t:{nameof(AtomGenerator)}");
 
-            //StringBuilder sb = new StringBuilder();
+            var guids = AssetDatabase.FindAssets($"t:{nameof(AtomGenerator)}");
             foreach (var guid in guids)
             {
-                // sb.Append("regenerate ");
                 var path = AssetDatabase.GUIDToAssetPath(guid);
-                // sb.AppendLine(path);
                 AssetDatabase.LoadAssetAtPath<AtomGenerator>(path).Generate();
             }
-            //Debug.Log(sb.ToString());
 
+            //Debug.Log(sb.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
which scripts to generate can now be added to assets.

I've just added it ontop of the current system, so there are some redundancies.

also it has to be tested if this would regenerate assets in packages.

it also contains an custom inspector for Folders, if a folder contains "Atom" it shows a button to generate a new generation file.
not sure if we should keep this, but it could be a nice user workflow improvement. e.g. for typical used atoms (IntVariable / FloatVariable) 