### PR TITLE
[BugFix] #196 (EventReferenceListener null reference)

### DIFF
--- a/Packages/Core/Runtime/Listeners/AtomEventReferenceListener.cs
+++ b/Packages/Core/Runtime/Listeners/AtomEventReferenceListener.cs
@@ -13,7 +13,7 @@ namespace UnityAtoms
     [EditorIcon("atom-icon-orange")]
     public abstract class AtomEventReferenceListener<T, E, ER, UER> : AtomBaseListener<T, E, UER>, IAtomListener<T>
         where E : AtomEvent<T>
-        where ER : IGetEvent, ISetEvent
+        where ER : IGetEvent, ISetEvent, new()
         where UER : UnityEvent<T>
     {
         /// <summary>
@@ -26,6 +26,6 @@ namespace UnityAtoms
         /// The Event Reference that we are listening to.
         /// </summary>
         [SerializeField]
-        private ER _eventReference = default(ER);
+        private ER _eventReference = new ER();
     }
 }


### PR DESCRIPTION
The EventReference isn't initialized as null anymore, but require a default constructor as generic constraint.

https://github.com/AdamRamberg/unity-atoms/issues/196

_______________

This PR will introduce a new constraint, most AtomBaseEventReference, as a default constructor is now required. on the other hand: all built-in AtomBaseEventReference subclasses do fulfill the requirement.

One could argue that the intended use is via the editor and unitys serialization system instead of via code, which would mean it isn't a bug, but instead a design decision. (I - personally - would see it as a bug, though)
