### PR TITLE
[Bugfix] #200 (UnregisterAll for AtomEventBase)

### DIFF
--- a/Packages/Core/Runtime/Events/AtomEvent.cs
+++ b/Packages/Core/Runtime/Events/AtomEvent.cs
@@ -26,7 +26,7 @@ namespace UnityAtoms
         protected event Action<T> _onEvent;
 
         /// <summary>
-        /// The event replays the specified number of old values to new subscribers. Works like a ReplaySubject in Rx. 
+        /// The event replays the specified number of old values to new subscribers. Works like a ReplaySubject in Rx.
         /// </summary>
         [SerializeField]
         [Range(0, 10)]
@@ -97,8 +97,9 @@ namespace UnityAtoms
         /// <summary>
         /// Unregister all handlers that were registered using the `Register` method.
         /// </summary>
-        public void UnregisterAll()
+        public override void UnregisterAll()
         {
+            base.UnregisterAll();
             _onEvent = null;
         }
 

--- a/Packages/Core/Runtime/Events/AtomEventBase.cs
+++ b/Packages/Core/Runtime/Events/AtomEventBase.cs
@@ -43,6 +43,14 @@ namespace UnityAtoms
         }
 
         /// <summary>
+        /// Unregister all handlers that were registered using the `Register` method.
+        /// </summary>
+        public virtual void UnregisterAll()
+        {
+            OnEventNoValue = null;
+        }
+
+        /// <summary>
         /// Register a Listener that in turn trigger all its associated handlers when the Event triggers.
         /// </summary>
         /// <param name="listener">The Listener to register.</param>


### PR DESCRIPTION
UnregisterAll did not unregister for listeners of OnEventNoValue.

this addresses https://github.com/AdamRamberg/unity-atoms/issues/200