### PR TITLE
Add AtomsSearchable attribute to indentify searchable atoms and apply…

### DIFF
--- a/Packages/BaseAtoms/Editor/AtomsSearchableAssetCreationMenu.cs
+++ b/Packages/BaseAtoms/Editor/AtomsSearchableAssetCreationMenu.cs
@@ -39,7 +39,7 @@ namespace UnityAtoms.Editor
             StringTree<Type> typeTree = new StringTree<Type>();
 
             foreach (var type in TypeCache.GetTypesWithAttribute<CreateAssetMenuAttribute>()
-                .Where(t => t.Namespace != null && t.Namespace.Contains("Atom")))
+                .Where(t => t.GetCustomAttribute<AtomsSearchable>(true) != null))
             {
                 var name = type.GetCustomAttribute<CreateAssetMenuAttribute>().menuName;
                 var i = name.LastIndexOf('/');

--- a/Packages/Core/Runtime/Attributes/AtomsSearchableAttribute.cs
+++ b/Packages/Core/Runtime/Attributes/AtomsSearchableAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace UnityAtoms
+{
+    /// <summary>
+    /// Attribute that makes an Atom searchable.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
+    public class AtomsSearchable : Attribute { }
+}

--- a/Packages/Core/Runtime/Attributes/AtomsSearchableAttribute.cs.meta
+++ b/Packages/Core/Runtime/Attributes/AtomsSearchableAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 758696991edcb4227bd2cba325398e0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Runtime/Attributes/EditorIcon.cs
+++ b/Packages/Core/Runtime/Attributes/EditorIcon.cs
@@ -5,7 +5,7 @@ namespace UnityAtoms
     /// <summary>
     /// Specify a texture name from your assets which you want to be assigned as an icon to the MonoScript.
     /// </summary>
-    [AttributeUsage(AttributeTargets.All, Inherited = true, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
     public class EditorIcon : Attribute
     {
         public EditorIcon(string name)

--- a/Packages/Core/Runtime/Base/BaseAtom.cs
+++ b/Packages/Core/Runtime/Base/BaseAtom.cs
@@ -5,6 +5,7 @@ namespace UnityAtoms
     /// <summary>
     /// None generic base class for all Atoms.
     /// </summary>
+    [AtomsSearchable]
     public abstract class BaseAtom : ScriptableObject
     {
         /// <summary>


### PR DESCRIPTION
Solves #214. Adds an `AtomsSearchable` attribute to indentify searchable atoms and applies that to `BaseAtom`. Also corrects `EditorIcon`'s usage flag. 