### PR TITLE
Trigger initial events for instancers

### DIFF
--- a/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs
+++ b/Packages/Core/Editor/Editors/AtomGeneratorEditor.cs
@@ -30,7 +30,6 @@ namespace UnityAtoms.Editor
 
         public override void OnInspectorGUI()
         {
-            Rect buttonRect = new Rect();
             var rect = GUILayoutUtility.GetRect(new GUIContent("Show"), EditorStyles.toolbarButton);
 
 

--- a/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
+++ b/Packages/Core/Runtime/EventReferences/AtomEventReference.cs
@@ -12,9 +12,9 @@ namespace UnityAtoms
     /// <typeparam name="VI">Variable Instancer of type `T`.</typeparam>
     /// <typeparam name="EI">Event Instancer of type `T`.</typeparam>
     public abstract class AtomEventReference<T, V, E, VI, EI> : AtomBaseEventReference<T, E, EI>, IGetEvent, ISetEvent
-        where V : IGetEvent, ISetEvent
+        where V : IGetOrCreateEvent, ISetEvent
         where E : AtomEvent<T>
-        where VI : IGetEvent, ISetEvent
+        where VI : IGetOrCreateEvent, ISetEvent
         where EI : AtomEventInstancer<T, E>
     {
         /// <summary>
@@ -27,8 +27,8 @@ namespace UnityAtoms
             {
                 switch (_usage)
                 {
-                    case (AtomEventReferenceUsage.VARIABLE): return _variable.GetEvent<E>();
-                    case (AtomEventReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer.GetEvent<E>();
+                    case (AtomEventReferenceUsage.VARIABLE): return _variable.GetOrCreateEvent<E>();
+                    case (AtomEventReferenceUsage.VARIABLE_INSTANCER): return _variableInstancer.GetOrCreateEvent<E>();
                     case (AtomEventReferenceUsage.EVENT_INSTANCER): return _eventInstancer.Event;
                     case (AtomEventReferenceUsage.EVENT):
                     default:

--- a/Packages/Core/Runtime/Interfaces/IGetOrCreateEvent.cs
+++ b/Packages/Core/Runtime/Interfaces/IGetOrCreateEvent.cs
@@ -1,0 +1,10 @@
+namespace UnityAtoms
+{
+    /// <summary>
+    /// Interface for getting or creating an event.
+    /// </summary>
+    public interface IGetOrCreateEvent
+    {
+        E GetOrCreateEvent<E>() where E : AtomEventBase;
+    }
+}

--- a/Packages/Core/Runtime/Interfaces/IGetOrCreateEvent.cs.meta
+++ b/Packages/Core/Runtime/Interfaces/IGetOrCreateEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad6eca56e172547c688d3a2d11dc23b7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
@@ -17,7 +17,7 @@ namespace UnityAtoms
     /// <typeparam name="F">Function of type T => T</typeparam>
     [EditorIcon("atom-icon-hotpink")]
     [DefaultExecutionOrder(Runtime.ExecutionOrder.VARIABLE_INSTANCER)]
-    public abstract class AtomVariableInstancer<V, P, T, E1, E2, F> : AtomBaseVariableInstancer<T, V>, IGetEvent, ISetEvent
+    public abstract class AtomVariableInstancer<V, P, T, E1, E2, F> : AtomBaseVariableInstancer<T, V>, IGetEvent, ISetEvent, IGetOrCreateEvent
         where V : AtomVariable<T, P, E1, E2, F>
         where P : struct, IPair<T>
         where E1 : AtomEvent<T>
@@ -29,12 +29,12 @@ namespace UnityAtoms
         /// </summary>
         protected override void ImplSpecificSetup()
         {
-            if (Base.HasChangedEvent)
+            if (Base.Changed != null)
             {
                 _inMemoryCopy.Changed = Instantiate(Base.Changed);
             }
 
-            if (Base.HasChangedWithHistoryEvent)
+            if (Base.ChangedWithHistory != null)
             {
                 _inMemoryCopy.ChangedWithHistory = Instantiate(Base.ChangedWithHistory);
             }
@@ -51,10 +51,7 @@ namespace UnityAtoms
         /// <returns>The event.</returns>
         public E GetEvent<E>() where E : AtomEventBase
         {
-            if (typeof(E) == typeof(E1) || typeof(E) == typeof(E2))
-                return _inMemoryCopy.GetEvent<E>();
-
-            throw new Exception($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");
+            return _inMemoryCopy.GetEvent<E>();
         }
 
         /// <summary>
@@ -64,18 +61,17 @@ namespace UnityAtoms
         /// <typeparam name="E"></typeparam>
         public void SetEvent<E>(E e) where E : AtomEventBase
         {
-            if (typeof(E) == typeof(E1))
-            {
-                _inMemoryCopy.Changed = (e as E1);
-                return;
-            }
-            if (typeof(E) == typeof(E2))
-            {
-                _inMemoryCopy.ChangedWithHistory = (e as E2);
-                return;
-            }
+            _inMemoryCopy.SetEvent<E>(e);
+        }
 
-            throw new Exception($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");
+        /// <summary>
+        /// Get event by type. Creates it if it doesn't exist.
+        /// </summary>
+        /// <typeparam name="E"></typeparam>
+        /// <returns>The event.</returns>
+        public E GetOrCreateEvent<E>() where E : AtomEventBase
+        {
+            return _inMemoryCopy.GetOrCreateEvent<E>();
         }
     }
 }

--- a/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
+++ b/Packages/Core/Runtime/VariableInstancers/AtomVariableInstancer.cs
@@ -29,15 +29,19 @@ namespace UnityAtoms
         /// </summary>
         protected override void ImplSpecificSetup()
         {
-            if (Base.Changed != null)
+            if (Base.HasChangedEvent)
             {
                 _inMemoryCopy.Changed = Instantiate(Base.Changed);
             }
 
-            if (Base.ChangedWithHistory != null)
+            if (Base.HasChangedWithHistoryEvent)
             {
                 _inMemoryCopy.ChangedWithHistory = Instantiate(Base.ChangedWithHistory);
             }
+
+            // Manually trigger initial events since base class has already instantiated Variable 
+            // and the Variable's OnEnable hook has therefore already been executed.
+            _inMemoryCopy.TriggerInitialEvents();
         }
 
         /// <summary>
@@ -47,10 +51,8 @@ namespace UnityAtoms
         /// <returns>The event.</returns>
         public E GetEvent<E>() where E : AtomEventBase
         {
-            if (typeof(E) == typeof(E1))
-                return (_inMemoryCopy.Changed as E);
-            if (typeof(E) == typeof(E2))
-                return (_inMemoryCopy.ChangedWithHistory as E);
+            if (typeof(E) == typeof(E1) || typeof(E) == typeof(E2))
+                return _inMemoryCopy.GetEvent<E>();
 
             throw new Exception($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");
         }

--- a/Packages/Core/Runtime/Variables/AtomVariable.cs
+++ b/Packages/Core/Runtime/Variables/AtomVariable.cs
@@ -47,6 +47,7 @@ namespace UnityAtoms
         [SerializeField]
         [FormerlySerializedAs("Changed")]
         private E1 _changed;
+        private bool _changedInstantiatedAtRuntime;
         public E1 Changed
         {
             get
@@ -54,7 +55,8 @@ namespace UnityAtoms
                 if (_changed == null)
                 {
                     _changed = ScriptableObject.CreateInstance<E1>();
-                    _changed.name = $"{name}_ChangedEvent_Runtime_{typeof(E1)}";
+                    _changed.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}ChangedEvent_Runtime_{typeof(E1)}";
+                    _changedInstantiatedAtRuntime = true;
                 }
                 return _changed;
             }
@@ -65,11 +67,17 @@ namespace UnityAtoms
         }
 
         /// <summary>
+        /// True if Variable has a Changed Event
+        /// </summary>
+        public bool HasChangedEvent { get => _changed != null; }
+
+        /// <summary>
         /// Changed with history Event triggered when the Variable value gets changed.
         /// </summary>
         [SerializeField]
         [FormerlySerializedAs("ChangedWithHistory")]
         private E2 _changedWithHistory;
+        private bool _changedWithHistoryInstantiatedAtRuntime;
         public E2 ChangedWithHistory
         {
             get
@@ -77,7 +85,8 @@ namespace UnityAtoms
                 if (_changedWithHistory == null)
                 {
                     _changedWithHistory = ScriptableObject.CreateInstance<E2>();
-                    _changedWithHistory.name = $"{name}_ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
+                    _changedWithHistory.name = $"{(String.IsNullOrWhiteSpace(name) ? "" : $"{name}_")}_ChangedWithHistoryEvent_Runtime_{typeof(E2)}";
+                    _changedWithHistoryInstantiatedAtRuntime = true;
                 }
                 return _changedWithHistory;
             }
@@ -86,6 +95,11 @@ namespace UnityAtoms
                 _changedWithHistory = value;
             }
         }
+
+        /// <summary>
+        /// True if Variable has a Changed with history Event
+        /// </summary>
+        public bool HasChangedWithHistoryEvent { get => _changedWithHistory != null; }
 
         /// <summary>
         /// Whether Changed Event should be triggered on OnEnable or not
@@ -162,6 +176,12 @@ namespace UnityAtoms
 #endif
         }
 
+        private void OnDisable()
+        {
+            if (_changedInstantiatedAtRuntime) _changed = null;
+            if (_changedWithHistoryInstantiatedAtRuntime) _changedWithHistory = null;
+        }
+
         /// <summary>
         /// Set initial values
         /// </summary>
@@ -169,18 +189,21 @@ namespace UnityAtoms
         {
             _oldValue = InitialValue;
             _value = InitialValue;
+
+            _changedInstantiatedAtRuntime = false;
+            _changedWithHistoryInstantiatedAtRuntime = false;
         }
 
         /// <summary>
         /// Trigger initial events if related options enabled
         /// </summary>
-        private void TriggerInitialEvents()
+        public void TriggerInitialEvents()
         {
-            if (Changed != null && _triggerChangedOnOnEnable)
+            if (HasChangedEvent && _triggerChangedOnOnEnable)
             {
                 Changed.Raise(Value);
             }
-            if (_triggerChangedWithHistoryOnOnEnable)
+            if (HasChangedWithHistoryEvent != null && _triggerChangedWithHistoryOnOnEnable)
             {
                 var pair = default(P);
                 pair.Item1 = _value;
@@ -246,8 +269,8 @@ namespace UnityAtoms
 
             if (triggerEvents)
             {
-                if (Changed != null) { Changed.Raise(_value); }
-                if (ChangedWithHistory != null)
+                if (HasChangedEvent) { Changed.Raise(_value); }
+                if (HasChangedWithHistoryEvent)
                 {
                     // NOTE: Doing new P() here, even though it is cleaner, generates garbage.
                     var pair = default(P);
@@ -332,9 +355,9 @@ namespace UnityAtoms
         /// </returns>
         public E GetEvent<E>() where E : AtomEventBase
         {
-            if (Changed is E evt1)
+            if (_changed is E evt1)
                 return evt1;
-            if (ChangedWithHistory is E evt2)
+            if (_changedWithHistory is E evt2)
                 return evt2;
 
             throw new NotSupportedException($"Event type {typeof(E)} not supported! Use {typeof(E1)} or {typeof(E2)}.");


### PR DESCRIPTION
- Trigger initial events for instancers
- Clean up event name for events instantiated at runtime
- Added properties to check if an event is set or not on a variable. This is useful in order to not accidentally create an event at runtime when just checking if it is null or not.
- Added logic to clean up events instantiated at runtime.

Fixes #210 